### PR TITLE
Fix the typo error generate by react-admin on Live category

### DIFF
--- a/apps/community-website/src/pages/admin/index.tsx
+++ b/apps/community-website/src/pages/admin/index.tsx
@@ -30,7 +30,7 @@ const AdminMainPage = () => {
                     icon={OndemandVideoIcon}
                 />
                 <Resource
-                    name="Lives"
+                    name="Livestreams"
                     list={LiveList}
                     edit={LiveEdit}
                     create={LiveCreate}

--- a/apps/community-website/src/shared/admin/DataProvider.tsx
+++ b/apps/community-website/src/shared/admin/DataProvider.tsx
@@ -157,7 +157,7 @@ const resourcesMap = {
                 )
             ).then((deletedVideos) => ({ data: deletedVideos })),
     },
-    Lives: {
+    Livestreams: {
         getList: () =>
             fetchLivestreamsWithThumbnail().then(({ data }) =>
                 data && data.listLivestreams && data.listLivestreams.items


### PR DESCRIPTION
This PR will fix the typo error generated by react-admin on the Live category.
React-admin puts Live in the plural and generates Life instead of Live.

![image](https://user-images.githubusercontent.com/71717523/141488088-69b2910d-ef35-413e-99a7-971437b1309d.png)

To solve this problem, we renamed the category to Livestreams and here is the result:

![preview_livestreams](https://user-images.githubusercontent.com/71717523/141488246-2692a014-f64e-4584-8a49-055954d66ad0.png)


